### PR TITLE
fixing variable name

### DIFF
--- a/XliffSync/Model/XlfDocument.ps1
+++ b/XliffSync/Model/XlfDocument.ps1
@@ -158,7 +158,7 @@ class XlfDocument {
     [System.Xml.XmlNode] FindTranslationUnitByXliffGeneratorNoteAndSourceText([string] $xliffGenNote, [string] $sourceText) {
         if ($this.xliffGeneratorNoteSourceUnitMap) {
             $key = @($xliffGenNote, $sourceText);
-            if ($this.xliffGeneratorNoteSourceUnitMa.ContainsKey($key)) {
+            if ($this.xliffGeneratorNoteSourceUnitMap.ContainsKey($key)) {
                 return $this.xliffGeneratorNoteSourceUnitMap[$key];
             }
             return $null;


### PR DESCRIPTION
Before fixing variable name it throws error:

You cannot call a method on a null-valued expression.
At C:\...\ps-xliff-sync-develop\XliffSync\Model\XlfDocument.ps1:161 char:17
+ ...         if ($this.xliffGeneratorNoteSourceUnitMa.ContainsKey($key)) { ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull