### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.1.0] 06-03-2021
+
+* Fix for `findByXliffGeneratorNoteAndSourceText` throwing error on variable not being found.
+* Fix for incorrect assumption of `xml:space="preserve"` which would lead to errors in an attempt to insert whitespace/nodes.
+* Fix/Improvement: Find by source (and developer note) would take the first unit with the same source text even if that unit did not have a translation, now it takes the first unit with the same source text with a translation to reuse translations.
+* Command `Check-XliffTranslations` now returns the units that contain problems as an array. Useful if you want to do something with the outputs, e.g., extract/show more information or completely fail your build pipeline if any problems are found.
+
+### Thank You
+
+* [Tomáš Žabčík](https://github.com/zabcik) for your [Pull Request #3 "fixing variable name"](https://github.com/rvanbekkum/ps-xliff-sync/pull/3)
+* [Simone Colombo](https://github.com/simooo985) for filing [Issue #2 "Error syncing Angular translations"](https://github.com/rvanbekkum/ps-xliff-sync/issues/2)
+
 ## [1.0.0] 02-09-2020
 
 * Initial version

--- a/XliffSync/Model/XlfDocument.ps1
+++ b/XliffSync/Model/XlfDocument.ps1
@@ -509,11 +509,16 @@ class XlfDocument {
                     $unit.ReplaceChild($targetNode, $targetChildNode);
                 }
                 elseif ($sourceChildNode) {
-                    $unit.InsertAfter($targetNode, $sourceChildNode.NextSibling);
+                    if ($unit.Attributes["xml:space"] -and ($unit.Attributes["xml:space"].Value -eq "preserve")) {
+                        $unit.InsertAfter($targetNode, $sourceChildNode.NextSibling);
 
-                    # Add the same whitespace after the target node.
-                    $newWhiteSpaceNode = $this.root.OwnerDocument.ImportNode($sourceChildNode.PreviousSibling, $true);
-                    $unit.InsertAfter($newWhiteSpaceNode, $targetNode);
+                        # Add the same whitespace after the target node.
+                        $newWhiteSpaceNode = $this.root.OwnerDocument.ImportNode($sourceChildNode.PreviousSibling, $true);
+                        $unit.InsertAfter($newWhiteSpaceNode, $targetNode);
+                    }
+                    else {
+                        $unit.InsertAfter($targetNode, $sourceChildNode);
+                    }
                 }
                 else {
                     $unit.AppendChild($targetNode);

--- a/XliffSync/Model/XlfDocument.ps1
+++ b/XliffSync/Model/XlfDocument.ps1
@@ -158,7 +158,7 @@ class XlfDocument {
     [System.Xml.XmlNode] FindTranslationUnitByXliffGeneratorNoteAndSourceText([string] $xliffGenNote, [string] $sourceText) {
         if ($this.xliffGeneratorNoteSourceUnitMap) {
             $key = @($xliffGenNote, $sourceText);
-            if ($this.xliffGeneratorNoteSourceUnitMa.ContainsKey($key)) {
+            if ($this.xliffGeneratorNoteSourceUnitMap.ContainsKey($key)) {
                 return $this.xliffGeneratorNoteSourceUnitMap[$key];
             }
             return $null;

--- a/XliffSync/Model/XlfDocument.ps1
+++ b/XliffSync/Model/XlfDocument.ps1
@@ -132,12 +132,18 @@ class XlfDocument {
                 if ($findBySourceAndDeveloperNote) {
                     $key = @($sourceText, $developerNote);
                     if (-not ($this.sourceDeveloperNoteUnitMap.ContainsKey($key))) {
-                        $this.sourceDeveloperNoteUnitMap.Add($key, $unit);
+                        $translation = $this.GetUnitTranslation($unit);
+                        if ($translation) {
+                            $this.sourceDeveloperNoteUnitMap.Add($key, $unit);
+                        }
                     }
                 }
 
                 if ($findBySource -and (-not ($this.sourceUnitMap.ContainsKey($sourceText)))) {
-                    $this.sourceUnitMap.Add($sourceText, $unit);
+                    $translation = $this.GetUnitTranslation($unit);
+                    if ($translation) {
+                        $this.sourceUnitMap.Add($sourceText, $unit);
+                    }
                 }
             }
         }

--- a/XliffSync/Public/Check-XliffTranslations.ps1
+++ b/XliffSync/Public/Check-XliffTranslations.ps1
@@ -163,6 +163,8 @@ function Check-XliffTranslations {
         Write-Host "Saving document to $targetPath";
         $targetDocument.SaveToFilePath($targetPath);
     }
+
+    return $missingTranslationUnits + $needWorkTranslationUnits;
 }
 
 function HasMissingTranslation {

--- a/XliffSync/XliffSync.psd1
+++ b/XliffSync/XliffSync.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'XliffSync.psm1'
-    ModuleVersion     = '1.0.0.0'
+    ModuleVersion     = '1.1.0.0'
     GUID              = 'a7614fd7-ce84-44db-9475-bc1f5fa4f0e5'
     Author            = 'Rob van Bekkum'
     CompanyName       = 'WSB Solutions B.V.'


### PR DESCRIPTION
* Fix for `findByXliffGeneratorNoteAndSourceText` throwing error on variable not being found.
* Fix for incorrect assumption of `xml:space="preserve"` which would lead to errors in an attempt to insert whitespace/nodes.
* Fix/Improvement: Find by source (and developer note) would take the first unit with the same source text even if that unit did not have a translation, now it takes the first unit with the same source text with a translation to reuse translations.
* Command `Check-XliffTranslations` now returns the units that contain problems as an array. Useful if you want to do something with the outputs, e.g., extract/show more information or completely fail your build pipeline if any problems are found.