### PR TITLE
New Functions Trans-XliffTranslations

### DIFF
--- a/XliffSync/Model/XlfDocument.ps1
+++ b/XliffSync/Model/XlfDocument.ps1
@@ -476,7 +476,7 @@ class XlfDocument {
             }
         }
         [string] $categoryAttributeValue = "XLIFF Sync";
-        return $notesParent.ChildNodes | Where-Object { ($_.name -eq 'note') -and ($_.Attributes) -and ($_.GetAttribute($categoryAttributeName) -eq $categoryAttributeValue)} | Select-Object -First 1;
+        return $notesParent.ChildNodes | Where-Object { ($_.name -eq 'note') -and ($_.Attributes) -and ($_.GetAttribute($categoryAttributeName) -eq $categoryAttributeValue) } | Select-Object -First 1;
     }
 
     [System.Xml.XmlNode] CreateTargetNode([System.Xml.XmlNode] $parentUnit, [string] $translation, [XlfTranslationState] $newTranslationState) {
@@ -530,7 +530,7 @@ class XlfDocument {
 
     [void] DeleteTargetNode([System.Xml.XmlElement] $unitNode) {
         if ($unitNode) {
-            [System.Xml.XmlNode] $targetNode = $unitNode.ChildNodes | Where-Object { $_.Name -eq 'target'} | Select-Object -First 1;
+            [System.Xml.XmlNode] $targetNode = $unitNode.ChildNodes | Where-Object { $_.Name -eq 'target' } | Select-Object -First 1;
             if ($targetNode) {
                 $unitNode.RemoveChild($targetNode);
             }
@@ -787,6 +787,22 @@ class XlfDocument {
         [xml] $fileContentXml = (New-Object System.Xml.XmlDocument);
         $fileContentXml.Load($filePath);
         return [XlfDocument]::LoadFromXmlDocument($fileContentXml);
+    }
+
+    [void] AddFromPath([string] $filePath) {
+        [xml] $fileContentXml = (New-Object System.Xml.XmlDocument);
+        $fileContentXml.Load($filePath);
+        $xlfDoc = [XlfDocument]::LoadFromXmlDocument($fileContentXml);        
+                
+        if ($null -ne $this.root) {
+            [xml] $xmlDoc = $this.root.OwnerDocument;
+            $group = [XlfDocument]::GetNode('group', $xlfDoc.root);          
+            $imported = $xmlDoc.ImportNode($group, $true);
+            $groupImported = [XlfDocument]::GetNode('group', $this.root);
+            $groupImported.AppendChild($imported);
+        } else {
+            $this.root = $xlfDoc.root;
+        }        
     }
 }
 

--- a/XliffSync/Public/Trans-XliffTranslations.ps1
+++ b/XliffSync/Public/Trans-XliffTranslations.ps1
@@ -4,7 +4,7 @@
  .Description
   Iterates through the translation units of a base XLIFF file and synchronizes them with a target XLIFF file.
  .Parameter sourcePath
-  Specifies the path to the base/source XLIFF file.
+  Specifies the path to the base/source XLIFF file / folder.
  .Parameter targetPath
   Specifies the path to the target XLIFF file.
  .Parameter unitMaps
@@ -20,17 +20,23 @@ function Trans-XliffTranslations {
         [Parameter(Mandatory = $false)]
         [ValidateSet("None", "Id", "All")]
         [string] $unitMaps = "All"
-    )
-
-    Write-Host "Loading source document $sourcePath";
-    [XlfDocument] $sourceDocument = [XlfDocument]::new();    
-    $sourceDocument.AddFromPath("c:\\Users\\zabcikt.CDL\\Repos\\SOL-BC-PPF\\PPFBCApps\\PPF-General\\Translations\\PPF-General.cs-CZ.xlf");
-    $sourceDocument.AddFromPath("c:\\Users\\zabcikt.CDL\\Repos\\SOL-BC-PPF\\PPFBCApps\\DocSAFE\\Translations\\DocSAFE.cs-CZ.xlf");     
-    $sourceDocument.AddFromPath("c:\\Users\\zabcikt.CDL\\Repos\\SOL-BC-PPF\\PPFBCApps\\ZAL\\Translations\\CDLZAL.cs-CZ.xlf");          
-    # $sourceDocument.SaveToFilePath("c:\\tmp\\test.xlf");
+    )    
     
     Write-Host "Loading target document $targetPath";
     [XlfDocument] $targetDocument = [XlfDocument]::LoadFromPath($targetPath);
+
+    $targetLanguage = $targetDocument.GetTargetLanguage();
+
+    Write-Host "Loading source document $sourcePath";
+    [XlfDocument] $sourceDocument = [XlfDocument]::new();    
+    $filter = "*.$targetLanguage.xlf";
+    Get-ChildItem -Path $sourcePath -Filter $filter -Recurse | foreach-object -process { 
+        if ($_) {
+            $targetPath2 = $_.FullName;
+            Write-Host "Loading target document $targetPath2";
+            $sourceDocument.AddFromPath($targetPath2);
+        }
+    }
     
     if ($unitMaps -ne "None") {
         Write-Host "Creating Maps in memory for source document's units.";

--- a/XliffSync/Public/Trans-XliffTranslations.ps1
+++ b/XliffSync/Public/Trans-XliffTranslations.ps1
@@ -1,8 +1,8 @@
 <# 
  .Synopsis
-  Synchronizes translation units and translations with a base XLIFF file to a target XLIFF file.
+  Translates translation units in target(s) with a translation base from source file(s).
  .Description
-  Iterates through the translation units of a base XLIFF file and synchronizes them with a target XLIFF file.
+  Iterates through the translation units of target file(s) and translates them with a translation base from source file(s).
  .Parameter sourcePath
   Specifies the path to the base/source XLIFF file / folder.
  .Parameter targetPath

--- a/XliffSync/Public/Trans-XliffTranslations.ps1
+++ b/XliffSync/Public/Trans-XliffTranslations.ps1
@@ -117,9 +117,7 @@ function Trans-XliffTranslations {
                     
             # Find by ID.
             [System.Xml.XmlNode] $sourceUnit = $sourceDocument.FindTranslationUnit($targetUnit.id);                
-
-            if ($sourceUnit) {
-                [System.Xml.XmlNode] $targetDocTranslUnit = $sourceDocument.FindTranslationUnitBySourceText($targetSourceText);
+            if ($sourceUnit) {                
                 $translation = $sourceDocument.GetUnitTranslation($sourceUnit);
             }
 

--- a/XliffSync/Public/Trans-XliffTranslations.ps1
+++ b/XliffSync/Public/Trans-XliffTranslations.ps1
@@ -1,0 +1,125 @@
+<# 
+ .Synopsis
+  Synchronizes translation units and translations with a base XLIFF file to a target XLIFF file.
+ .Description
+  Iterates through the translation units of a base XLIFF file and synchronizes them with a target XLIFF file.
+ .Parameter sourcePath
+  Specifies the path to the base/source XLIFF file.
+ .Parameter targetPath
+  Specifies the path to the target XLIFF file.
+ .Parameter unitMaps
+  Specifies for which search purposes this command should create in-memory maps in preparation of syncing.
+#>
+function Trans-XliffTranslations {
+    Param (
+        [Parameter(Mandatory = $true)]
+        [string] $sourcePath,        
+        [Parameter(Mandatory = $true)]
+        [string] $targetPath,                
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("None", "Id", "All")]
+        [string] $unitMaps = "All"
+    )
+
+    Write-Host "Loading source document $sourcePath";
+    [XlfDocument] $sourceDocument = [XlfDocument]::LoadFromPath($sourcePath);    
+
+    Write-Host "Loading target document $targetPath";
+    [XlfDocument] $targetDocument = [XlfDocument]::LoadFromPath($targetPath);
+
+    $sourceTranslationsHashTable = @{};    
+    if ($unitMaps -ne "None") {
+        Write-Host "Creating Maps in memory for target document's units.";
+        if ($unitMaps -eq "Id") {
+            $sourceDocument.CreateUnitMaps($false, $false, $false, $false, $false);
+            $targetDocument.CreateUnitMaps($false, $false, $false, $false, $false);
+        }
+        else {            
+            [bool] $findBySource = $true;
+            $sourceDocument.CreateUnitMaps($false, $false, $false, $false, $findBySource);
+            $targetDocument.CreateUnitMaps($false, $false, $false, $false, $findBySource);
+        }
+    }
+
+    Write-Host "Retrieving translation units from source document";
+    [int] $unitCount = $sourceDocument.TranslationUnitNodes().Count;
+    [int] $i = 0;
+    [int] $onePercentCount = $unitCount / 100;
+    if ($onePercentCount -eq 0) {
+        $onePercentCount = 1;
+    }
+    
+    Write-Host "Processing unit nodes... (Please be patient)";
+    [string] $progressMessage = "Syncing translation units."
+    if ($reportProgress) {
+        Write-Progress -Activity $progressMessage -PercentComplete 0;       
+    }
+
+    $sourceDocument.TranslationUnitNodes() | ForEach-Object {
+        [System.Xml.XmlNode] $sourceUnit = $_;
+
+        [string] $sourceText = $sourceDocument.GetUnitSourceText($sourceUnit);      
+        if (-not $sourceTranslationsHashTable.ContainsKey($sourceText)) {
+            [System.Xml.XmlNode] $sourceDocTranslUnit = $sourceDocument.FindTranslationUnitBySourceText($sourceText);
+            if ($sourceDocTranslUnit) {
+                [string] $translation = $null;     
+                $translation = $sourceDocument.GetUnitTranslation($sourceDocTranslUnit);
+                if ($translation) {
+                    $sourceTranslationsHashTable[$sourceText] = $translation;
+                }
+            }
+        }
+    }
+
+    $targetDocument.TranslationUnitNodes() | ForEach-Object {
+        [System.Xml.XmlNode] $targetUnit = $_;
+
+        if ($reportProgress) {
+            $i++;
+            if ($i % $onePercentCount -eq 0) {
+                $percentage = ($i / $unitCount) * 100;   
+                Write-Progress -Activity $progressMessage -PercentComplete $percentage;                
+            }
+        }
+
+        # Read target "sourceText"
+        [string] $targetSourceText = $targetDocument.GetUnitSourceText($targetUnit);        
+        # Write-Host "Source: $targetSourceText";        
+
+        # Read target "targetText"
+        [string] $targetTargetText = $targetDocument.GetUnitTranslation($targetUnit);
+        # Write-Host "Target: $targetTargetText";
+
+        # Needs-Translation
+        if ($targetSourceText -and (-not $targetTargetText)) {                               
+
+            [string] $translation = $null;     
+                    
+            # Find by ID.
+            [System.Xml.XmlNode] $sourceUnit = $sourceDocument.FindTranslationUnit($targetUnit.id);                
+
+            if ($sourceUnit) {
+                [System.Xml.XmlNode] $targetDocTranslUnit = $sourceDocument.FindTranslationUnitBySourceText($targetSourceText);
+                $translation = $sourceDocument.GetUnitTranslation($sourceUnit);
+            }
+
+            # Find by Source.
+            if (-not $translation) {
+
+                if ($sourceTranslationsHashTable.ContainsKey($targetSourceText)) {
+                    $translation = $sourceTranslationsHashTable[$targetSourceText];
+                }                                
+            }
+        
+            if ($translation) {
+                $targetDocument.MergeUnit($targetUnit, $targetUnit, $translation);
+                # Write-Host "Translation: $translation";
+            }
+
+        }
+    }
+
+    Write-Host "Saving document to $targetPath"    
+    $targetDocument.SaveToFilePath($targetPath);
+}

--- a/XliffSync/Public/Trans-XliffTranslations.ps1
+++ b/XliffSync/Public/Trans-XliffTranslations.ps1
@@ -23,21 +23,33 @@ function Trans-XliffTranslations {
     )
 
     Write-Host "Loading source document $sourcePath";
-    [XlfDocument] $sourceDocument = [XlfDocument]::LoadFromPath($sourcePath);    
-
+    [XlfDocument] $sourceDocument = [XlfDocument]::new();    
+    $sourceDocument.AddFromPath("c:\\Users\\zabcikt.CDL\\Repos\\SOL-BC-PPF\\PPFBCApps\\PPF-General\\Translations\\PPF-General.cs-CZ.xlf");
+    $sourceDocument.AddFromPath("c:\\Users\\zabcikt.CDL\\Repos\\SOL-BC-PPF\\PPFBCApps\\DocSAFE\\Translations\\DocSAFE.cs-CZ.xlf");     
+    $sourceDocument.AddFromPath("c:\\Users\\zabcikt.CDL\\Repos\\SOL-BC-PPF\\PPFBCApps\\ZAL\\Translations\\CDLZAL.cs-CZ.xlf");          
+    # $sourceDocument.SaveToFilePath("c:\\tmp\\test.xlf");
+    
     Write-Host "Loading target document $targetPath";
     [XlfDocument] $targetDocument = [XlfDocument]::LoadFromPath($targetPath);
-
-    $sourceTranslationsHashTable = @{};    
+    
     if ($unitMaps -ne "None") {
-        Write-Host "Creating Maps in memory for target document's units.";
+        Write-Host "Creating Maps in memory for source document's units.";
         if ($unitMaps -eq "Id") {
-            $sourceDocument.CreateUnitMaps($false, $false, $false, $false, $false);
-            $targetDocument.CreateUnitMaps($false, $false, $false, $false, $false);
+            $sourceDocument.CreateUnitMaps($false, $false, $false, $false, $false);            
         }
         else {            
             [bool] $findBySource = $true;
-            $sourceDocument.CreateUnitMaps($false, $false, $false, $false, $findBySource);
+            $sourceDocument.CreateUnitMaps($false, $false, $false, $false, $findBySource);            
+        }
+    }
+
+    if ($unitMaps -ne "None") {
+        Write-Host "Creating Maps in memory for target document's units.";
+        if ($unitMaps -eq "Id") {            
+            $targetDocument.CreateUnitMaps($false, $false, $false, $false, $false);
+        }
+        else {            
+            [bool] $findBySource = $true;            
             $targetDocument.CreateUnitMaps($false, $false, $false, $false, $findBySource);
         }
     }
@@ -56,6 +68,7 @@ function Trans-XliffTranslations {
         Write-Progress -Activity $progressMessage -PercentComplete 0;       
     }
 
+    $sourceTranslationsHashTable = @{};    
     $sourceDocument.TranslationUnitNodes() | ForEach-Object {
         [System.Xml.XmlNode] $sourceUnit = $_;
 

--- a/XliffSync/Test-Trans.ps1
+++ b/XliffSync/Test-Trans.ps1
@@ -5,4 +5,5 @@ Import-Module -Name "C:\Users\zabcikt.CDL\GitHub\ps-xliff-sync\XliffSync\XliffSy
 Trans-XliffTranslations `
     -source "C:\Users\zabcikt.CDL\GitHub\ps-xliff-sync\XliffSync\Tests\TestTransSource.cs-CZ.xlf" `
     -target "C:\Users\zabcikt.CDL\GitHub\ps-xliff-sync\XliffSync\Tests\TestTransTarget.cs-CZ.xlf"
-    # -unitMaps 'None'
+# -source "C:\tmp\" `
+# -unitMaps 'None'

--- a/XliffSync/Test-Trans.ps1
+++ b/XliffSync/Test-Trans.ps1
@@ -1,5 +1,8 @@
+cls
+
 Import-Module -Name "C:\Users\zabcikt.CDL\GitHub\ps-xliff-sync\XliffSync\XliffSync.psm1" -Force -DisableNameChecking;
 
 Trans-XliffTranslations `
     -source "C:\Users\zabcikt.CDL\GitHub\ps-xliff-sync\XliffSync\Tests\TestTransSource.cs-CZ.xlf" `
-    -target "C:\Users\zabcikt.CDL\GitHub\ps-xliff-sync\XliffSync\Tests\TestTransTarget.cs-CZ.xlf"    
+    -target "C:\Users\zabcikt.CDL\GitHub\ps-xliff-sync\XliffSync\Tests\TestTransTarget.cs-CZ.xlf"
+    # -unitMaps 'None'

--- a/XliffSync/Test-Trans.ps1
+++ b/XliffSync/Test-Trans.ps1
@@ -1,0 +1,5 @@
+Import-Module -Name "C:\Users\zabcikt.CDL\GitHub\ps-xliff-sync\XliffSync\XliffSync.psm1" -Force -DisableNameChecking;
+
+Trans-XliffTranslations `
+    -source "C:\Users\zabcikt.CDL\GitHub\ps-xliff-sync\XliffSync\Tests\TestTransSource.cs-CZ.xlf" `
+    -target "C:\Users\zabcikt.CDL\GitHub\ps-xliff-sync\XliffSync\Tests\TestTransTarget.cs-CZ.xlf"    

--- a/XliffSync/Test-Trans.ps1
+++ b/XliffSync/Test-Trans.ps1
@@ -1,9 +1,5 @@
-cls
-
-Import-Module -Name "C:\Users\zabcikt.CDL\GitHub\ps-xliff-sync\XliffSync\XliffSync.psm1" -Force -DisableNameChecking;
+Import-Module -Name (Resolve-Path -Path "XliffSync\XliffSync.psm1") -Force -DisableNameChecking;
 
 Trans-XliffTranslations `
-    -source "C:\Users\zabcikt.CDL\GitHub\ps-xliff-sync\XliffSync\Tests\TestTransSource.cs-CZ.xlf" `
-    -target "C:\Users\zabcikt.CDL\GitHub\ps-xliff-sync\XliffSync\Tests\TestTransTarget.cs-CZ.xlf"
-# -source "C:\tmp\" `
-# -unitMaps 'None'
+    -source (Resolve-Path -Path "XliffSync\Tests\TestTransSource.cs-CZ.xlf") `
+    -target (Resolve-Path -Path "XliffSync\Tests\TestTransTarget.cs-CZ.xlf")

--- a/XliffSync/Tests/TestTransSource.cs-CZ.xlf
+++ b/XliffSync/Tests/TestTransSource.cs-CZ.xlf
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en-US" target-language="nl-BE" original="ParseFromDevNote">
+    <body>
+      <group>    
+        <trans-unit id="Table 38627395 - Field 883711285 - Property 2879900210" size-unit="" translate="yes">
+          <source>Entry No.</source>
+          <target>Číslo položky</target>
+          <note from="Developer" annotates="general" priority="2" />
+          <note from="Xliff Generator" annotates="general" priority="3">Table CDL Advance Link - Field Entry No. - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="Table 38627395 - Field 149522872 - Property 2879900210" size-unit="" translate="yes">
+          <source>Entry Type</source>
+          <target>Typ položky</target>
+          <note from="Developer" annotates="general" priority="2" />
+          <note from="Xliff Generator" annotates="general" priority="3">Table CDL Advance Link - Field Entry Type - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="Table 38627395 - Field 592951229 - Property 2879900210" size-unit="" translate="yes">
+          <source>Amount (LCY)</source>
+          <target>Částka (LM)</target>
+          <note from="Developer" annotates="general" priority="2" />
+          <note from="Xliff Generator" annotates="general" priority="3">Table CDL Advance Link - Field Amount (LCY) - Property Caption</note>
+        </trans-unit>        
+      </group>
+    </body>
+  </file>
+</xliff>

--- a/XliffSync/Tests/TestTransTarget.cs-CZ.xlf
+++ b/XliffSync/Tests/TestTransTarget.cs-CZ.xlf
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en-US" target-language="nl-BE" original="ParseFromDevNote">
+    <body>
+      <group>
+        <trans-unit id="Table 38627395 - Field 883711285 - Property 2879900210" size-unit="" translate="yes">
+          <source>Entry No.</source>
+          <target />
+          <note from="Developer" annotates="general" priority="2" />
+          <note from="Xliff Generator" annotates="general" priority="3">Table CDL Advance Link - Field Entry No. - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="Table 38627395 - Field 149522872 - Property 2879900210" size-unit="" translate="yes">
+          <source>Entry Type</source>
+          <target />
+          <note from="Developer" annotates="general" priority="2" />
+          <note from="Xliff Generator" annotates="general" priority="3">Table CDL Advance Link - Field Entry Type - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="Table 00000000000 - Field 592951229 - Property 2879900210" size-unit="" translate="yes">
+          <source>Amount (LCY)</source>
+          <target />
+          <note from="Developer" annotates="general" priority="2" />
+          <note from="Xliff Generator" annotates="general" priority="3">Table CDL Advance Link - Field Amount (LCY) - Property Caption</note>
+        </trans-unit>
+      </group>
+    </body>
+  </file>
+</xliff>

--- a/XliffSync/Tests/TestTransTarget.cs-CZ.xlf
+++ b/XliffSync/Tests/TestTransTarget.cs-CZ.xlf
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en-US" target-language="nl-BE" original="ParseFromDevNote">
+  <file datatype="xml" source-language="en-US" target-language="cs-CZ" original="ParseFromDevNote">
     <body>
       <group>
         <trans-unit id="Table 38627395 - Field 883711285 - Property 2879900210" size-unit="" translate="yes">

--- a/XliffSync/XliffSync.psd1
+++ b/XliffSync/XliffSync.psd1
@@ -5,12 +5,12 @@
     Author            = 'Rob van Bekkum'
     CompanyName       = 'WSB Solutions B.V.'
     Copyright         = '(c) 2020 Rob van Bekkum. All rights reserved.'
-	Description       = 'Keep XLIFF translation files easily in sync with a generated base-XLIFF file.'
+    Description       = 'Keep XLIFF translation files easily in sync with a generated base-XLIFF file.'
     PowerShellVersion = '5.0'
-    FunctionsToExport = @('Check-XliffTranslations', 'Get-XliffTranslationsDiff', 'Sync-XliffTranslations')
-    PrivateData = @{
+    FunctionsToExport = @('Check-XliffTranslations', 'Get-XliffTranslationsDiff', 'Sync-XliffTranslations', 'Trans-XliffTranslations')
+    PrivateData       = @{
         PSData = @{
-            Tags = @('xliff', 'localization', 'translation', 'dynamics-365', 'synchronization')
+            Tags       = @('xliff', 'localization', 'translation', 'dynamics-365', 'synchronization')
             LicenseUri = 'https://opensource.org/licenses/MIT'
             ProjectUri = 'https://github.com/rvanbekkum/ps-xliff-sync'    
         }


### PR DESCRIPTION
Hello Rob,

I created new function Trans-XliffTranslations.
This function uses already translated xlf files as "Translation Base".
This function supports multiple source files and multiple target files.
With this "Translation Base" translates files target files.
Translation from "Translation Base" is used only if it is unique.
This is useful when you need to re-use already translated texts...

Source files = translation base files
Target files = files that need to be translated

BR
zabaq