### PR TITLE
Renamed functions and added aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.3.0] T.B.D.
+
+* Renamed functions to adhere to approved verbs and added aliases to still support the old function names (GitHub issue [#10](https://github.com/rvanbekkum/ps-xliff-sync/issues/10))
+
+### Thank You
+
+* [Jan Hoek](https://github.com/fvet) for filing [Issue #10 "Consider using standard verbs for your cmdlets"](https://github.com/rvanbekkum/ps-xliff-sync/issues/10)
+
 ## [1.2.0] 20-05-2021
 
 * New function `Trans-XliffTranslations` by [Tomáš Žabčík](https://github.com/zabcik)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Please check the documentation of the function for more information and the avai
 
 ### Check XLIFF Translations
 
-The `Test-XliffTranslations` function (or `Check-XliffTranslations`) will check for missing translations and/or for problems in translations in a specified XLIFF file.
+The `Test-XliffTranslations` function (alias: `Check-XliffTranslations`) will check for missing translations and/or for problems in translations in a specified XLIFF file.
 To use the function you will need to specify the target file (`-targetPath`) and whether you want to check for missing translations (`-checkForMissing`) and/or problems in translations (`-checkForProblems`).
 If you let the function check for problems, then you can use the `translationRules` parameter to specify which technical validation rules should be applied.
 
@@ -70,7 +70,7 @@ $unitsWithProblems = Test-XliffTranslations -targetPath "C:\MyProject\My Project
 
 When finished the function will report the number of missing translations and number of detected problems.
 Translation units without translations will be marked with `state="needs-translation"` and translation units with a problem in the translation will be marked with a 'needs-work' state and an "XLIFF Sync"-note that explains the detected problem.
-The function will return the translation units with problems.
+The function will return the translation units with problems, which you can assign to a variable (e.g., `$unitsWithProblems`) or omit, to have the output printed.
 
 Please check the documentation of the function for more information and the available parameters.
 
@@ -88,7 +88,7 @@ Please check the documentation of the function for more information and the avai
 
 ### Apply Translations to XLIFF Translation Files
 
-The `Set-XliffTranslations` function will apply translations to the translation units in a target file with a translation base from a source file.
+The `Set-XliffTranslations` function (alias: `Trans-XliffTranslations`) will apply translations to the translation units in a target file with a translation base from a source file.
 
 An example usage:
 

--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ Please check the documentation of the function for more information and the avai
 
 ### Check XLIFF Translations
 
-The `Check-XliffTranslations` function will check for missing translations and/or for problems in translations in a specified XLIFF file.
+The `Test-XliffTranslations` function (or `Check-XliffTranslations`) will check for missing translations and/or for problems in translations in a specified XLIFF file.
 To use the function you will need to specify the target file (`-targetPath`) and whether you want to check for missing translations (`-checkForMissing`) and/or problems in translations (`-checkForProblems`).
 If you let the function check for problems, then you can use the `translationRules` parameter to specify which technical validation rules should be applied.
 
 An example usage:
 
 ```powershell
-Check-XliffTranslations -targetPath "C:\MyProject\My Project.nl-NL.xlf" -checkForMissing -reportProgress
+Test-XliffTranslations -targetPath "C:\MyProject\My Project.nl-NL.xlf" -checkForMissing -reportProgress
 ```
 
 When finished the function will report the number of missing translations and number of detected problems.
@@ -81,6 +81,18 @@ An example usage:
 
 ```powershell
 Get-XliffTranslationsDiff -originalPath "C:\MyProject\OriginalVersion.xlf" -newPath "C:\MyProject\NewVersion.xlf" -diffPath "C:\MyProject\Diff.xlf" -reportProgress
+```
+
+Please check the documentation of the function for more information and the available parameters.
+
+### Apply Translations to XLIFF Translation Files
+
+The `Set-XliffTranslations` function will apply translations to the translation units in a target file with a translation base from a source file.
+
+An example usage:
+
+```powershell
+Set-XliffTranslations -sourcePath "C:\MyProject\translationSource.xlf" -targetPath "C:\MyProject\translationTarget.xlf"
 ```
 
 Please check the documentation of the function for more information and the available parameters.

--- a/README.md
+++ b/README.md
@@ -65,11 +65,12 @@ If you let the function check for problems, then you can use the `translationRul
 An example usage:
 
 ```powershell
-Test-XliffTranslations -targetPath "C:\MyProject\My Project.nl-NL.xlf" -checkForMissing -reportProgress
+$unitsWithProblems = Test-XliffTranslations -targetPath "C:\MyProject\My Project.nl-NL.xlf" -checkForMissing -reportProgress
 ```
 
 When finished the function will report the number of missing translations and number of detected problems.
 Translation units without translations will be marked with `state="needs-translation"` and translation units with a problem in the translation will be marked with a 'needs-work' state and an "XLIFF Sync"-note that explains the detected problem.
+The function will return the translation units with problems.
 
 Please check the documentation of the function for more information and the available parameters.
 

--- a/XliffSync/Public/Get-XliffTranslationsDiff.ps1
+++ b/XliffSync/Public/Get-XliffTranslationsDiff.ps1
@@ -78,3 +78,4 @@ function Get-XliffTranslationsDiff {
     Write-Host "Saving document to $diffPath"
     $diffDocument.SaveToFilePath($diffPath);
 }
+Export-ModuleMember -Function Get-XliffTranslationsDiff

--- a/XliffSync/Public/Set-XliffTranslations.ps1
+++ b/XliffSync/Public/Set-XliffTranslations.ps1
@@ -10,7 +10,7 @@
  .Parameter unitMaps
   Specifies for which search purposes this command should create in-memory maps in preparation of syncing.
 #>
-function Trans-XliffTranslations {
+function Set-XliffTranslations {
     Param (
         [Parameter(Mandatory = $true)]
         [string] $sourcePath,
@@ -140,3 +140,4 @@ function Trans-XliffTranslations {
     Write-Host "Saving document to $targetPath"
     $targetDocument.SaveToFilePath($targetPath);
 }
+Set-Alias -Name Set-XliffTranslations -Value Trans-XliffTranslations

--- a/XliffSync/Public/Set-XliffTranslations.ps1
+++ b/XliffSync/Public/Set-XliffTranslations.ps1
@@ -140,4 +140,5 @@ function Set-XliffTranslations {
     Write-Host "Saving document to $targetPath"
     $targetDocument.SaveToFilePath($targetPath);
 }
-Set-Alias -Name Set-XliffTranslations -Value Trans-XliffTranslations
+Set-Alias -Name Trans-XliffTranslations -Value Set-XliffTranslations
+Export-ModuleMember -Function Set-XliffTranslations -Alias Trans-XliffTranslations

--- a/XliffSync/Public/Sync-XliffTranslations.ps1
+++ b/XliffSync/Public/Sync-XliffTranslations.ps1
@@ -283,3 +283,4 @@ function Sync-XliffTranslations {
     Write-Host "Saving document to $targetPath"
     $mergedDocument.SaveToFilePath($targetPath);
 }
+Export-ModuleMember -Function Sync-XliffTranslations

--- a/XliffSync/Public/Test-XliffTranslations.ps1
+++ b/XliffSync/Public/Test-XliffTranslations.ps1
@@ -351,4 +351,5 @@ function IsConsecutiveSpacesMismatch {
 
     return $false;
 }
-Set-Alias -Name Test-XliffTranslations -Value Check-XliffTranslations
+Set-Alias -Name Check-XliffTranslations -Value Test-XliffTranslations
+Export-ModuleMember -Function Test-XliffTranslations -Alias Check-XliffTranslations

--- a/XliffSync/Public/Test-XliffTranslations.ps1
+++ b/XliffSync/Public/Test-XliffTranslations.ps1
@@ -24,7 +24,7 @@
  .Parameter printProblems
   Specifies whether the command should print all detected problems.
 #>
-function Check-XliffTranslations {
+function Test-XliffTranslations {
     Param (
         [Parameter(Mandatory=$true)]
         [string] $targetPath,
@@ -351,3 +351,4 @@ function IsConsecutiveSpacesMismatch {
 
     return $false;
 }
+Set-Alias -Name Test-XliffTranslations -Value Check-XliffTranslations

--- a/XliffSync/XliffSync.psd1
+++ b/XliffSync/XliffSync.psd1
@@ -8,6 +8,7 @@
     Description       = 'Keep XLIFF translation files easily in sync with a generated base-XLIFF file.'
     PowerShellVersion = '5.0'
     FunctionsToExport = @('Get-XliffTranslationsDiff', 'Set-XliffTranslations', 'Sync-XliffTranslations', 'Test-XliffTranslations')
+    AliasesToExport   = @('Check-XliffTranslations', 'Trans-XliffTranslations')
     PrivateData       = @{
         PSData = @{
             Tags       = @('xliff', 'localization', 'translation', 'dynamics-365', 'synchronization')

--- a/XliffSync/XliffSync.psd1
+++ b/XliffSync/XliffSync.psd1
@@ -4,11 +4,10 @@
     GUID              = 'a7614fd7-ce84-44db-9475-bc1f5fa4f0e5'
     Author            = 'Rob van Bekkum'
     CompanyName       = 'WSB Solutions B.V.'
-    Copyright         = '(c) 2020 Rob van Bekkum. All rights reserved.'
+    Copyright         = '(c) 2021 Rob van Bekkum. All rights reserved.'
     Description       = 'Keep XLIFF translation files easily in sync with a generated base-XLIFF file.'
     PowerShellVersion = '5.0'
     FunctionsToExport = @('Get-XliffTranslationsDiff', 'Set-XliffTranslations', 'Sync-XliffTranslations', 'Test-XliffTranslations')
-    AliasesToExport   = @('Check-XliffTranslations', 'Trans-XliffTranslations')
     PrivateData       = @{
         PSData = @{
             Tags       = @('xliff', 'localization', 'translation', 'dynamics-365', 'synchronization')

--- a/XliffSync/XliffSync.psd1
+++ b/XliffSync/XliffSync.psd1
@@ -1,18 +1,18 @@
 @{
     RootModule        = 'XliffSync.psm1'
-    ModuleVersion     = '1.2.0.0'
+    ModuleVersion     = '1.3.0.0'
     GUID              = 'a7614fd7-ce84-44db-9475-bc1f5fa4f0e5'
     Author            = 'Rob van Bekkum'
     CompanyName       = 'WSB Solutions B.V.'
     Copyright         = '(c) 2020 Rob van Bekkum. All rights reserved.'
     Description       = 'Keep XLIFF translation files easily in sync with a generated base-XLIFF file.'
     PowerShellVersion = '5.0'
-    FunctionsToExport = @('Check-XliffTranslations', 'Get-XliffTranslationsDiff', 'Sync-XliffTranslations', 'Trans-XliffTranslations')
+    FunctionsToExport = @('Get-XliffTranslationsDiff', 'Set-XliffTranslations', 'Sync-XliffTranslations', 'Test-XliffTranslations')
     PrivateData       = @{
         PSData = @{
             Tags       = @('xliff', 'localization', 'translation', 'dynamics-365', 'synchronization')
             LicenseUri = 'https://opensource.org/licenses/MIT'
-            ProjectUri = 'https://github.com/rvanbekkum/ps-xliff-sync'    
+            ProjectUri = 'https://github.com/rvanbekkum/ps-xliff-sync'
         }
     }
 }

--- a/XliffSync/XliffSync.psm1
+++ b/XliffSync/XliffSync.psm1
@@ -24,6 +24,7 @@ foreach($folder in @('Public'))
     }
 }
 
+# Export Public Functions
 . (Join-Path $PSScriptRoot "Public\Get-XliffTranslationsDiff.ps1")
 . (Join-Path $PSScriptRoot "Public\Set-XliffTranslations.ps1")
 . (Join-Path $PSScriptRoot "Public\Sync-XliffTranslations.ps1")

--- a/XliffSync/XliffSync.psm1
+++ b/XliffSync/XliffSync.psm1
@@ -19,10 +19,12 @@ foreach($folder in @('Public'))
         $files = Get-ChildItem -Path $rootPath -Filter *.ps1 -Recurse
 
         # dot source each file
-        $files | Where-Object{ $_.name -NotLike '*.Tests.ps1'} | 
+        $files | Where-Object{ $_.name -NotLike '*.Tests.ps1'} |
             ForEach-Object{Write-Verbose $_.BaseName; . $_.FullName}
     }
 }
 
-# Export Public Functions
-Export-ModuleMember -Function (Get-ChildItem -Path "$PSScriptRoot\Public\*.ps1").BaseName
+. (Join-Path $PSScriptRoot "Public\Get-XliffTranslationsDiff.ps1")
+. (Join-Path $PSScriptRoot "Public\Set-XliffTranslations.ps1")
+. (Join-Path $PSScriptRoot "Public\Sync-XliffTranslations.ps1")
+. (Join-Path $PSScriptRoot "Public\Test-XliffTranslations.ps1")


### PR DESCRIPTION
* `Trans-XliffTranslations` becomes `Set-XliffTranslations`
* `Check-XliffTranslations` becomes `Test-XliffTranslations`
* Added aliases for the old function names

Additional changes:
* Remove trailing spaces
* Update README and Changelog