### PR TITLE
Resolve-Path gets an error if the file does not exist yet.

### DIFF
--- a/XliffSync/Model/XlfDocument.ps1
+++ b/XliffSync/Model/XlfDocument.ps1
@@ -646,7 +646,9 @@ class XlfDocument {
     }
 
     [void] SaveToFilePath([string] $filePath) {
-        $filePath = Resolve-Path $filePath
+        if(Test-Path $filePath){
+            $filePath = Resolve-Path $filePath
+        }
         $this.root.OwnerDocument.Save($filePath);
     }
 

--- a/XliffSync/Public/Sync-XliffTranslations.ps1
+++ b/XliffSync/Public/Sync-XliffTranslations.ps1
@@ -105,7 +105,7 @@ function Sync-XliffTranslations {
 
     [XlfDocument] $targetDocument = $null;
     if (-not $targetPath) {
-        $targetPath = $sourcePath -replace '(\.g)?\.xlf', ".$targetLanguage.xlf"
+        $targetPath = (Resolve-Path $sourcePath) -replace '(\.g)?\.xlf', ".$targetLanguage.xlf"
     }
 
     if (Test-Path $targetPath) {


### PR DESCRIPTION
Hi Rob,

after our chat at Directions I'm just trying to migrate our solution to XliffSync 😊 But for that we have to get the pipeline running. I'm calling the Powershell command like this

```Powershell
Sync-XliffTranslations -sourcePath .\Translations\Core.g.xlf -targetLanguage 'de-DE' -parseFromDeveloperNote -parseFromDeveloperNoteOverwrite -parseFromDeveloperNoteSeparator "||" -detectSourceTextChanges $false -reportProgress
```
This should create a `Core.de-DE.xlf` which does not exist yet. The `$targetPath` is currently determined on the relative path of the `$sourcePath` variable. And the script works perfectly fine with that. But then it comes to `$mergedDocument.SaveToFilePath($targetPath);` in the `Sync-XliffTranslations.ps1` file and the function wants to resolve the `$targetpath` to get the full path (which does not exist) and throws an error. 
With this PR I would like to set the `$targetPath` directly with the full path by using the `(Resolve-Path $sourcePath)` - because that file exists and the resolving will succeed.
And then, in the `SaveToFilePath` function, I don't have to resolve it again (which still would fail as the file still does not exist) which is why I added the `if(Test-Path $filePath)`. But as I then already have the full file path, the command `$this.root.OwnerDocument.Save($filePath);` succeeds.

I hope I could explain it good enough, so that you could follow me :D

All the best,
David