### PR TITLE
Fix splitting if the separator consists of more than one character

### DIFF
--- a/XliffSync/Model/XlfDocument.ps1
+++ b/XliffSync/Model/XlfDocument.ps1
@@ -577,7 +577,7 @@ class XlfDocument {
             return $null;
         }
 
-        [string[]] $translationEntries = $developerNoteText.Split($this.parseFromDeveloperNoteSeparator);
+        [string[]] $translationEntries = [regex]::Split($developerNoteText, [regex]::Escape($this.parseFromDeveloperNoteSeparator))
         [string] $translationText = $null;
 
         for ($i = 0; $i -lt $translationEntries.Length; $i++) {


### PR DESCRIPTION
Hi Rob,

we're using the following command in our pipeline
```powershell
Sync-XliffTranslations -sourcePath ".\Core.g.xlf" -targetLanguage 'de-DE' -parseFromDeveloperNote -parseFromDeveloperNoteOverwrite -parseFromDeveloperNoteSeparator "||" -detectSourceTextChanges:$false
```
The issue is that the separator consists of more than one character, because the powershell` $string.Split('text')` function splits the `$string`-variable by each character (= by `t`, `e`, `x`, and `t`).
So in our example:
```al
HTMLFileTypeTok: Label 'HTML Files (*.html)|*.html', Comment = 'de-DE=HTML-Dateien (*.html)|*.html';
```
The result of `"de-DE=HTML-Dateien (*.html)|*.html".Split('||')` is `de-DE=HTML-Dateien (*.html)` which is wrong and unfortunately in this case we're using it as filter for a file dialog, so the wrong translation leads to a runtime error.

Best regards
David