### PR TITLE
Skip apps without translations

### DIFF
--- a/XliffSync/Public/bc/Test-BcAppXliffTranslations.ps1
+++ b/XliffSync/Public/bc/Test-BcAppXliffTranslations.ps1
@@ -62,6 +62,9 @@ function Test-BcAppXliffTranslations {
         Write-Host "##[group]Checking translations for `"$_`""
         $appProjectFolder = Join-Path $buildProjectFolder $_
         $appTranslationsFolder = Join-Path $appProjectFolder "Translations"
+        if (-not (Test-Path $appTranslationsFolder)) {
+            break
+        }
         Write-Host "Retrieving translation files from $appTranslationsFolder"
         $baseXliffFile = Get-ChildItem -Path $appTranslationsFolder -Filter '*.g.xlf'
         Write-Host "Base translation file $($baseXliffFile.FullName)"


### PR DESCRIPTION
Working with multiple apps in the same project, I think it's convenient pass the whole list of apps and skip the validation for the once without translations (because not needed).