### PR TITLE
Error handling optimized when AzureDevOps equals  'error'

### DIFF
--- a/XliffSync/Public/bc/Test-BcAppXliffTranslations.ps1
+++ b/XliffSync/Public/bc/Test-BcAppXliffTranslations.ps1
@@ -105,7 +105,9 @@ function Test-BcAppXliffTranslations {
 
         $issueCount = $allUnitsWithIssues.Count
         if (($AzureDevOps -eq 'error') -and ($issueCount -gt 0)) {
-            throw "$issueCount issues detected in translation files!"
+            Write-Host "##vso[task.logissue type=error]$issueCount issues detected in translation files!"
+            Write-Host "##vso[task.complete result=Failed;]Make step fail"
+            exit 0
         }
     }
 }


### PR DESCRIPTION
As promised the optimization of the error handling when AzureDevOps equals 'error'. That results in an failed task and aborting the pipeline execution.