### PR TITLE
Change severity of "There are no target translation files" message in Test-BcAppXliffTranslations to be based on -AzureDevOps parameter

### DIFF
--- a/XliffSync/Public/bc/Test-BcAppXliffTranslations.ps1
+++ b/XliffSync/Public/bc/Test-BcAppXliffTranslations.ps1
@@ -109,7 +109,7 @@ function Test-BcAppXliffTranslations {
         }
 
         if ($targetXliffFiles.Count -eq 0) {
-            Write-Host "##vso[task.logissue type=warning]There are no target translation files for $($baseXliffFile.Name)"
+            Write-Host "##vso[task.logissue type=$AzureDevOps]There are no target translation files for $($baseXliffFile.Name)"
         }
         Write-Host "##[endgroup]"
 

--- a/XliffSync/Public/bc/Test-BcAppXliffTranslations.ps1
+++ b/XliffSync/Public/bc/Test-BcAppXliffTranslations.ps1
@@ -108,7 +108,7 @@ function Test-BcAppXliffTranslations {
             }
         }
 
-        if ($targetXliffFiles.Count -eq 0) {
+        if (@("error","warning").Contains($AzureDevOps) -and ($targetXliffFiles.Count -eq 0)) {
             Write-Host "##vso[task.logissue type=$AzureDevOps]There are no target translation files for $($baseXliffFile.Name)"
         }
         Write-Host "##[endgroup]"


### PR DESCRIPTION
Hi,

I have noticed that missing translation target files are currently not causing errors even if the parameter $AzureDevOps is set to "error". This would really help us better enforce translations.