### PR TITLE
fix: address self-closing format issue

### DIFF
--- a/XliffSync/Model/XlfDocument.ps1
+++ b/XliffSync/Model/XlfDocument.ps1
@@ -640,10 +640,8 @@ class XlfDocument {
             $filePath = Resolve-Path $filePath
         }
 
-        if ($this.useSelfClosingTags) {
-            foreach ($elem in $this.root.OwnerDocument.SelectNodes("descendant::*[not(node())]")) {
-                $elem.IsEmpty = $true;
-            }
+        foreach ($elem in $this.root.OwnerDocument.SelectNodes("descendant::*[not(node())]")) {
+            $elem.IsEmpty = $this.useSelfClosingTags;
         }
 
         $this.root.OwnerDocument.Save($filePath);


### PR DESCRIPTION
for some reason, when using `Sync-XliffTranslations` using 1.9.0 release without `-UseSelfClosing` switch is producing a file with self-closing tags.

We recently added .NET Core 7 on our server running DevOps agents, maybe it's the cause.
This ensure the value of Empty tag is always provided properly.

--

You'll find bellow an example of changes resulting from Xliff-Sync usage without this fix.

```
          <trans-unit id="PageExtension 4199398035 - Control 4274268573 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 1567633909">
            <source>Specifies the value of the User unlock field.</source>
++          <target state="needs-translation" />
--          <target state="needs-translation"></target>
            <note from="Developer" annotates="general" priority="2"></note>
            <note from="Xliff Generator" annotates="general" priority="3">PageExtension UEZ Vendor Ledger Entries - Control UEZ User unlock - Property ToolTip</note>
          </trans-unit>
```

This is not valid when the `useSelfClosing` flag is set on false.

--

related to #38 due to some default configuration of .NET Framework