### PR TITLE
Implemented copyFromTarget parameter

### DIFF
--- a/XliffSync/Model/XlfDocument.ps1
+++ b/XliffSync/Model/XlfDocument.ps1
@@ -318,7 +318,7 @@ class XlfDocument {
 
         if ($needsTranslation -and $targetNode) {
             if ($translation) {
-                $targetNode.InnerText = $translation;
+                $targetNode.InnerXml = $translation;
                 if ($this.Version() -eq "1.2") {
                     $this.UpdateStateAttributes($targetNode, [XlfTranslationState]::Translated);
                 }
@@ -548,7 +548,7 @@ class XlfDocument {
         if ((-not $translationNode) -and (-not $translationNode.HasChildNodes)) {
             return $null;
         }
-        return $translationNode.ChildNodes[0].Value;
+        return $translationNode.InnerXml;
     }
 
     [string] GetUnitDeveloperNote([System.Xml.XmlNode] $unitNode) {

--- a/XliffSync/Public/Sync-XliffTranslations.ps1
+++ b/XliffSync/Public/Sync-XliffTranslations.ps1
@@ -37,6 +37,10 @@
   Specifies whether (initial) translations should be copied from the source text (note: only when there is not already an existing translation in the target).
  .Parameter copyFromSourceOverwrite
   Specifies whether translations copied from the source text should overwrite existing translations.
+ .Parameter copyFromTarget
+  Specifies whether (initial) translations should be copied from the target text (note: only when there is not already an existing translation in the target).
+ .Parameter copyFromTargetOverwrite
+  Specifies whether translations copied from the target text should overwrite existing translations.
  .Parameter detectSourceTextChanges
   Specifies whether changes in the source text of a trans-unit should be detected. If a change is detected, the target state is changed to needs-adaptation and a note is added to indicate the translation should be reviewed.
  .Parameter missingTranslation
@@ -80,6 +84,8 @@ function Sync-XliffTranslations {
         [char[]] $parseFromDeveloperNoteTrimCharacters,
         [switch] $copyFromSource,
         [switch] $copyFromSourceOverwrite,
+        [switch] $copyFromTarget,
+        [switch] $copyFromTargetOverwrite,
         [Parameter(Mandatory = $false)]
         [boolean] $detectSourceTextChanges = $true,
         [Parameter(Mandatory = $false)]
@@ -236,7 +242,7 @@ function Sync-XliffTranslations {
             }
         }
 
-        if ((-not $translation) -and ($copyFromSource -or $parseFromDeveloperNote)) {
+        if ((-not $translation) -and ($copyFromSource -or $copyFromTarget -or $parseFromDeveloperNote)) {
             [bool] $hasNoTranslation = $false;
             if ($targetUnit) {
                 [string] $targetTranslation = $targetDocument.GetUnitTranslation($targetUnit);
@@ -247,6 +253,7 @@ function Sync-XliffTranslations {
 
             [bool] $shouldParseFromDevNote = $parseFromDeveloperNote -and ($hasNoTranslation -or $parseFromDeveloperNoteOverwrite);
             [bool] $shouldCopyFromSource = $copyFromSource -and ($hasNoTranslation -or $copyFromSourceOverwrite);
+            [bool] $shouldCopyFromTarget = $copyFromTarget -and ($hasNoTranslation -or $copyFromTargetOverwrite);
 
             if ((-not $translation) -and $shouldParseFromDevNote) {
                 $translation = $mergedDocument.GetUnitTranslationFromDeveloperNote($unit);
@@ -268,6 +275,9 @@ function Sync-XliffTranslations {
             }
             if ((-not $translation) -and $shouldCopyFromSource) {
                 $translation = $mergedDocument.GetUnitSourceText($unit);
+            }
+            if ((-not $translation) -and $shouldCopyFromTarget) {
+                $translation = $mergedDocument.GetUnitTranslation($unit);
             }
         }
 


### PR DESCRIPTION
Hi everyone,

I'm using Angular's native i18n module to support multiple languages. I'm currently facing a challenge with closely related languages like German (de), Swiss German (de-CH), and Austrian German (de-AT), which only have minor differences. To avoid manually copying translations between them, I want to automate the synchronization while still allowing selective overrides.

Unfortunately, I couldn't find a built-in way to handle this. The copyFromSource option doesn't work in this case.

Since our source translation file is in English and already successfully synced to German using our sync script, the German file still uses English as the source language. As a result, I can't use copyFromSource to sync from German to Swiss or Austrian German.

Our current flow looks like this:
    _.g.xlf_ → _.de.xlf_
    _.de.xlf_ → _.de-CH.xlf_
    _.de.xlf_ → _.de-AT.xlf_

To support this, I’ve added a copyFromTarget parameter that copies translations from the target instead of the source. This allows me to "fork" translations from the German file.

This change should be fully backward-compatible and introduce no breaking changes.

Thank you & best regards